### PR TITLE
Makefile Upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,97 +1,121 @@
-
-CFLAGS = $(shell gsl-config --cflags) -std=c++0x
-##CFLAGS += -ggdb -gdwarf-2 -Wall -I include -O
-CFLAGS +=-O3 -I include
-##CFLAGS += -D _DEBUG # comment this line if you don't need compile with debug; if you don't need tracing function, define TRACING_DISABLED
-MPCFLAG = -I /cm/shared/mpi/openmpi/2.1/intel/17.0/include
-LIBS   = $(shell gsl-config --libs)
-
-##CC     = icpc
-##MPCC 	= mpiicpc
+#
+#  Update 2020-01-06: 
+#  o Use VPATH for finding cpp file in different directories -- this simplifies rules
+#  o Abort if gsl-config isn't available
+#  o Fixed (INTEL) compiler search 0=found | 1=notfound ; make conditional simple (ifeq 0|1)
+#  o Also use conditional for GCC
+#  o For objects, use basename to get base file name
+#  o Clean up directory prefix (shorten variable names and group)
+#  o Simplified obj and bin rule logic and readability.
+#  o put rules in canonical order
+#  -- now the makefile looks a bit cleaner                    Kent milfeld@tacc.utexas.edu
+#
+# TODO: use function to create VPATH
+# TODO: Check this out on OSX
+# TODO: Fix MPI after learning purpose
+#
+VPATH=src/boundary_conditions:src/classes:src/io:src/math:src/parser:src/reactions:src/system_setup:src/trajectory_functions
 
 BDIR   = bin
 ODIR   = obj
 SDIR   = src
 EDIR   = EXEs
-EPDIR   = EXE_PAR
-OS    := $(shell uname)
-INTEL := $(shell which icpc)
+EPDIR  = EXE_PAR
 
-ifndef INTEL
-	CC = g++
-	MPCC = mpicxx
+.PHONY: any
+
+#               REQUIREMENTS: gls and directories
+
+hasGSL = $(shell type gsl-config >/dev/null 2>&1; echo $$?)
+ifeq ($(hasGSL),1)
+	$(error " GSL must be installed, and gsl-config must be in path.")
 else
-	CC = icpc
-	MPCC = mpiicpc
+	$(shell mkdir -p bin)
+	$(shell mkdir -p obj)
 endif
 
-##ifeq ($(OS),Linux)
-##	_OBJS = $(shell find $(SDIR) -name "*.cpp" | sed -r 's/(\.cc|.cpp)/.o/')
-##else
-	_OBJS = $(shell find $(SDIR) -name "*.cpp" | sed -E 's/(\.cc|.cpp)/.o/' | sed -E 's/src/./')
-##endif
+#               EXECUTABLE SETUP for serial, MPI, OpenMP (omp)
+#
+ifeq (serial,$(MAKECMDGOALS))
+	_EXEC = nerdss
+endif
 
-_EXECUTABLES = 	nerdss \
-##		template \
-##		test_angles \
-##		test_loops \
-##		rd_gen_reweightPBC \
-		rd_boundfraconly \
+ifeq (mpi,$(MAKECMDGOALS))
+	_EXEC = nerdss_mpi
+         DEFS = -DMPI
+endif
 
-_PAREXECUTABLES = 	nerdss_mpi \
+ifeq (omp,$(MAKECMDGOALS))
+	_EXEC  = nerdss_omp
+         DEFS  = -DOMP
+         PLANG = -fopenmp
+endif
 
+ifeq (clean,$(MAKECMDGOALS))
+	MAKECMDGOALS = dummy
+endif
 
-
-OBJS = $(patsubst %,$(ODIR)/%,$(_OBJS))
-
-EXECUTABLES = $(patsubst %,$(BDIR)/%,$(_EXECUTABLES))
-
-PAREXECUTABLES = $(patsubst %,$(BDIR)/%,$(_PAREXECUTABLES))
-
-
-
-_SOURCES = ${_EXECUTABLES:=.cpp}
-SOURCES = $(patsubst %,$(EDIR)/%,$(_SOURCES))
-
-_PARSOURCES = ${_PAREXECUTABLES:=.cpp}
-PARSOURCES = $(patsubst %,$(EPDIR)/%,$(_PARSOURCES))
+         EXEC  = $(patsubst %,$(BDIR)/%,$(_EXEC))
 
 
+OS    := $(shell uname)
+INTEL  = $(shell type icpc       >/dev/null 2>&1; echo $$?)
 
-all: dirs $(EXECUTABLES) 
-#$(PAREXECUTABLES)
+CFLAGS = $(shell gsl-config --cflags) -std=c++0x
+LIBS   = $(shell gsl-config --libs)
 
-$(ODIR)/%.o: $(SDIR)/%.cpp
-	@echo "Compiling $<"
-	$(CC) $(CFLAGS) $(CFLAGS2) -c $< -o $@  
-	@echo "------------"
 
-$(EXECUTABLES): $(OBJS)
+#---------------COMPILER SETUP
+
+ifeq ($(GCC),0)          # Found/Use Intel icpc compiler
+	CC      = g++
+	MPCC    = mpicxx
+	CFLAGS += -O3 -I include
+#	MPCFLAG = -I /cm/shared/mpi/openmpi/2.1/intel/17.0/include
+endif
+
+
+ifeq ($(INTEL),0)          # Found/Use Intel icpc compiler
+	CC      = icpc
+	MPCC    = mpicxx
+	CFLAGS += -O3 -I include
+endif
+
+#---------------OBJECT FILES
+
+ifeq ($(OS),Linux)
+       _OBJS = $(shell find $(SDIR) -name "*.cpp" | xargs -n 1 basename | sed -r 's/(\.cc|.cpp)/.o/')
+else
+       _OBJS = $(shell find $(SDIR) -name "*.cpp" | xargs -n 1 basename | sed -E 's/(\.cc|.cpp)/.o/')
+endif
+
+        OBJS = $(patsubst %,$(ODIR)/%,$(_OBJS))
+
+
+#---------------RULES
+
+syntax:
+	@echo "------------------------------------"
+	@printf '\033[31m%s\033[0m\n' "   USAGE: make serial|mpi|omp"
+	@echo "------------------------------------"
+	exit 0
+
+#             Rules: for $(MAKECMDGOALS)  serial,     mpi, or            omp            build 
+#                        $(EXEC)          bin/nerdss, bin/nerdss_mpi or /binnerdss_omp
+$(MAKECMDGOALS):$(EXEC)
+	@echo "Finished making (re-)building $(MAKECMDGOALS) version, $(EXEC)."
+
+$(EXEC): $(OBJS)
 	@echo "Compiling $(EDIR)/$(@F).cpp"
-	$(CC) $(CFLAGS) $(CFLAGS2) -o $@ $(EDIR)/$(@F).cpp $(OBJS) $(LIBS)
+	$(CC) $(CFLAGS) $(CFLAGS2) -o $@ $(EDIR)/$(@F).cpp $(OBJS) $(LIBS) $(PLANG)
 	@echo "------------"
 
-$(PAREXECUTABLES): $(OBJS)
-	@echo "Compiling $(EPDIR)/$(@F).cpp"
-	$(MPCC) $(CFLAGS) $(CFLAGS2) -o $@ $(EPDIR)/$(@F).cpp $(OBJS) $(LIBS)
+obj/%.o: %.cpp
+	@echo "Compiling $<"
+	$(CC) $(CFLAGS) $(CFLAGS2) -c $< -o $@  $(PLANG) $(DEFS)
 	@echo "------------"
-
-
-dirs: 
-	mkdir -p bin
-	mkdir -p obj
-	mkdir -p obj/classes
-	mkdir -p obj/math
-	mkdir -p obj/parser
-	mkdir -p obj/shared
-	mkdir -p obj/reactions
-	mkdir -p obj/system_setup
-	mkdir -p obj/boundary_conditions
-	mkdir -p obj/trajectory_functions
-	mkdir -p obj/io
-
 
 clean:
 	rm -rf $(ODIR) bin
 
-
+# Reference: https://www.gnu.org/software/make/manual/html_node/Quick-Reference.html

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@
 #  -- now the makefile looks a bit cleaner                    Kent milfeld@tacc.utexas.edu
 #
 # TODO: use function to create VPATH
-# TODO: Check this out on OSX
 # TODO: Fix MPI after learning purpose
+# TODO: Make rules for *.hpp's
+#
 #
 VPATH=src/boundary_conditions:src/classes:src/io:src/math:src/parser:src/reactions:src/system_setup:src/trajectory_functions
 
@@ -28,10 +29,10 @@ EPDIR  = EXE_PAR
 
 hasGSL = $(shell type gsl-config >/dev/null 2>&1; echo $$?)
 ifeq ($(hasGSL),1)
-	$(error " GSL must be installed, and gsl-config must be in path.")
+$(error " GSL must be installed, and gsl-config must be in path.")
 else
-	$(shell mkdir -p bin)
-	$(shell mkdir -p obj)
+$(shell mkdir -p bin)
+$(shell mkdir -p obj)
 endif
 
 #               EXECUTABLE SETUP for serial, MPI, OpenMP (omp)
@@ -59,7 +60,8 @@ endif
 
 
 OS    := $(shell uname)
-INTEL  = $(shell type icpc       >/dev/null 2>&1; echo $$?)
+INTEL  = $(shell type icpc  >/dev/null 2>&1; echo $$?)
+GCC    = $(shell type g++   >/dev/null 2>&1; echo $$?)
 
 CFLAGS = $(shell gsl-config --cflags) -std=c++0x
 LIBS   = $(shell gsl-config --libs)
@@ -107,15 +109,16 @@ $(MAKECMDGOALS):$(EXEC)
 
 $(EXEC): $(OBJS)
 	@echo "Compiling $(EDIR)/$(@F).cpp"
-	$(CC) $(CFLAGS) $(CFLAGS2) -o $@ $(EDIR)/$(@F).cpp $(OBJS) $(LIBS) $(PLANG)
+	$(CC) $(CFLAGS) $(CFLAGS2) -o $@ $(EDIR)/$(@F).cpp -Iinclude $(OBJS) $(LIBS) $(PLANG)
 	@echo "------------"
 
 obj/%.o: %.cpp
-	@echo "Compiling $<"
-	$(CC) $(CFLAGS) $(CFLAGS2) -c $< -o $@  $(PLANG) $(DEFS)
+	@echo "Compiling $< at $(<F) $(<D)"
+	$(CC) $(CFLAGS) $(CFLAGS2) -c $< -o $@ -Iinclude $(PLANG) $(DEFS)
 	@echo "------------"
 
 clean:
 	rm -rf $(ODIR) bin
 
 # Reference: https://www.gnu.org/software/make/manual/html_node/Quick-Reference.html
+#            https://www.cmcrossroads.com/article/basics-vpath-and-vpath


### PR DESCRIPTION
Changes work on TACC's Frontera machine and Mac (OS X).
#  o Uses VPATH for finding cpp file in different directories -- this simplifies rules
#  o Aborts if gsl-config isn't available
#  o Fixed (INTEL) compiler search 0=found | 1=notfound ; makes conditional simple (ifeq 0|1)
#  o Also uses conditional for GCC
#  o For objects, uses basename to get base file name
#  o Cleaned up directory prefix (shorten variable names and group)
#  o Simplified obj and bin rule logic and readability.
#  o put rules in canonical order
#  -- now the makefile looks a bit cleaner 